### PR TITLE
Avoid using shallow-copy for proto message

### DIFF
--- a/relay/beacon.go
+++ b/relay/beacon.go
@@ -95,12 +95,12 @@ func (pr *Prover) findLCPeriodByHeight(height ibcexported.Height, latestPeriod u
 	return 0, fmt.Errorf("something wong...: target_block_number=%v latest_period=%v", bn, latestPeriod)
 }
 
-func (pr *Prover) buildExecutionUpdate(executionHeader beacon.ExecutionPayloadHeader) (*lctypes.ExecutionUpdate, error) {
-	stateRootBranch, err := generate_execution_payload_proof(&executionHeader, EXECUTION_STATE_ROOT_INDEX)
+func (pr *Prover) buildExecutionUpdate(executionHeader *beacon.ExecutionPayloadHeader) (*lctypes.ExecutionUpdate, error) {
+	stateRootBranch, err := generate_execution_payload_proof(executionHeader, EXECUTION_STATE_ROOT_INDEX)
 	if err != nil {
 		return nil, err
 	}
-	blockNumberBranch, err := generate_execution_payload_proof(&executionHeader, EXECUTION_BLOCK_NUMBER_INDEX)
+	blockNumberBranch, err := generate_execution_payload_proof(executionHeader, EXECUTION_BLOCK_NUMBER_INDEX)
 	if err != nil {
 		return nil, err
 	}

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -192,7 +192,7 @@ func (pr *Prover) GetLatestFinalizedHeader() (headers core.Header, err error) {
 		return nil, err
 	}
 	lcUpdate := res.Data.ToProto()
-	executionHeader := res.Data.FinalizedHeader.Execution
+	executionHeader := &res.Data.FinalizedHeader.Execution
 	executionUpdate, err := pr.buildExecutionUpdate(executionHeader)
 	if err != nil {
 		return nil, err
@@ -245,7 +245,7 @@ func (pr *Prover) buildNextSyncCommitteeUpdateForCurrent(period uint64, trustedH
 		return nil, err
 	}
 	lcUpdate := res.Data.ToProto()
-	executionHeader := res.Data.FinalizedHeader.Execution
+	executionHeader := &res.Data.FinalizedHeader.Execution
 	executionUpdate, err := pr.buildExecutionUpdate(executionHeader)
 	if err != nil {
 		return nil, err
@@ -292,7 +292,7 @@ func (pr *Prover) buildNextSyncCommitteeUpdateForNext(period uint64, trustedHeig
 	}
 	lcUpdate := res.Data.ToProto()
 	executionHeader := res.Data.FinalizedHeader.Execution
-	executionUpdate, err := pr.buildExecutionUpdate(executionHeader)
+	executionUpdate, err := pr.buildExecutionUpdate(&executionHeader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This also suppresses the warnings by `go vet`.