### PR TITLE
Add context.Context to Prover methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.5
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/ibc-go/v8 v8.2.1
-	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.13
+	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16
 	github.com/ethereum/go-ethereum v1.14.12
-	github.com/hyperledger-labs/yui-relayer v0.5.10
+	github.com/hyperledger-labs/yui-relayer v0.5.11
 	github.com/prysmaticlabs/fastssz v0.0.0-20241008181541-518c4ce73516
 	github.com/prysmaticlabs/prysm/v5 v5.2.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.13 h1:RbYtraeZwN55qfbzfoDIJPK8CWWx5dWfO8CfnvS+dhk=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.13/go.mod h1:dxL5umpjncKRw7iBFE2W+dGpmmWOiggth0aQsJrtLKM=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16 h1:C4xwZ1Pq5O+ITjP5UphpwThtTHnWiTe0V4pckEvqfwI=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16/go.mod h1:sf+ti1uM1joxhukxIyj8oDQ5yf7d+e+nl+3vtn9f5CM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -759,8 +759,8 @@ github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXM
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/yui-relayer v0.5.10 h1:j35SRowNfVDU3gvq4Th3Wy8ufRD5K4wbXDLQAGOgT8w=
-github.com/hyperledger-labs/yui-relayer v0.5.10/go.mod h1:kJvSmuagdDsSlvbnHtEHbhmkUlAS43/ArLDwukOKSlo=
+github.com/hyperledger-labs/yui-relayer v0.5.11 h1:tBDWJa96jQhxL9zLDbB94VvSgw0f8Xk9tqPuKMT3ARw=
+github.com/hyperledger-labs/yui-relayer v0.5.11/go.mod h1:kJvSmuagdDsSlvbnHtEHbhmkUlAS43/ArLDwukOKSlo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/relay/beacon.go
+++ b/relay/beacon.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/datachainlab/ethereum-ibc-relay-prover/beacon"
@@ -84,7 +85,7 @@ func (pr *Prover) getSlotAtTimestamp(timestamp uint64) (uint64, error) {
 
 // returns a period corresponding to a given execution block number
 func (pr *Prover) getPeriodWithBlockNumber(blockNumber uint64) (uint64, error) {
-	timestamp, err := pr.chain.Timestamp(pr.newHeight(int64(blockNumber)))
+	timestamp, err := pr.chain.Timestamp(context.TODO(), pr.newHeight(int64(blockNumber)))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This PR is part of the second phase of OpenTelemetry integration.
For more details, refer to https://github.com/hyperledger-labs/yui-relayer/pull/153.

I have confirmed that I can build the module as follows:

```console
$ go test ./...
?       github.com/datachainlab/ethereum-ibc-relay-prover       [no test files]
?       github.com/datachainlab/ethereum-ibc-relay-prover/beacon        [no test files]
?       github.com/datachainlab/ethereum-ibc-relay-prover/light-clients/ethereum/types  [no test files]
?       github.com/datachainlab/ethereum-ibc-relay-prover/relay [no test files]
```