### PR TITLE
Use context appropriately

### DIFF
--- a/beacon/client.go
+++ b/beacon/client.go
@@ -1,6 +1,7 @@
 package beacon
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -14,28 +15,29 @@ import (
 var SupportedVersions = []string{"deneb", "electra"}
 
 type Client struct {
-	endpoint string
+	endpoint   string
+	httpClient *http.Client
 }
 
 func NewClient(endpoint string) Client {
-	return Client{endpoint: endpoint}
+	return Client{endpoint: endpoint, httpClient: &http.Client{}}
 }
 
 func IsSupportedVersion(v string) bool {
 	return slices.Contains(SupportedVersions, v)
 }
 
-func (cl Client) GetGenesis() (*Genesis, error) {
+func (cl Client) GetGenesis(ctx context.Context) (*Genesis, error) {
 	var res GenesisResponse
-	if err := cl.get("/eth/v1/beacon/genesis", &res); err != nil {
+	if err := cl.get(ctx, "/eth/v1/beacon/genesis", &res); err != nil {
 		return nil, err
 	}
 	return ToGenesis(res)
 }
 
-func (cl Client) GetBlockRoot(slot uint64, allowOptimistic bool) (*BlockRootResponse, error) {
+func (cl Client) GetBlockRoot(ctx context.Context, slot uint64, allowOptimistic bool) (*BlockRootResponse, error) {
 	var res BlockRootResponse
-	if err := cl.get(fmt.Sprintf("/eth/v1/beacon/blocks/%v/root", slot), &res); err != nil {
+	if err := cl.get(ctx, fmt.Sprintf("/eth/v1/beacon/blocks/%v/root", slot), &res); err != nil {
 		return nil, err
 	}
 	if !allowOptimistic && res.ExecutionOptimistic {
@@ -44,20 +46,20 @@ func (cl Client) GetBlockRoot(slot uint64, allowOptimistic bool) (*BlockRootResp
 	return &res, nil
 }
 
-func (cl Client) GetFinalityCheckpoints() (*StateFinalityCheckpoints, error) {
+func (cl Client) GetFinalityCheckpoints(ctx context.Context) (*StateFinalityCheckpoints, error) {
 	var res StateFinalityCheckpointResponse
-	if err := cl.get("/eth/v1/beacon/states/head/finality_checkpoints", &res); err != nil {
+	if err := cl.get(ctx, "/eth/v1/beacon/states/head/finality_checkpoints", &res); err != nil {
 		return nil, err
 	}
 	return ToStateFinalityCheckpoints(res)
 }
 
-func (cl Client) GetBootstrap(finalizedRoot []byte) (*LightClientBootstrapResponse, error) {
+func (cl Client) GetBootstrap(ctx context.Context, finalizedRoot []byte) (*LightClientBootstrapResponse, error) {
 	if len(finalizedRoot) != 32 {
 		return nil, fmt.Errorf("finalizedRoot length must be 32: actual=%v", finalizedRoot)
 	}
 	var res LightClientBootstrapResponse
-	if err := cl.get(fmt.Sprintf("/eth/v1/beacon/light_client/bootstrap/0x%v", hex.EncodeToString(finalizedRoot[:])), &res); err != nil {
+	if err := cl.get(ctx, fmt.Sprintf("/eth/v1/beacon/light_client/bootstrap/0x%v", hex.EncodeToString(finalizedRoot[:])), &res); err != nil {
 		return nil, err
 	}
 	if !IsSupportedVersion(res.Version) {
@@ -66,9 +68,9 @@ func (cl Client) GetBootstrap(finalizedRoot []byte) (*LightClientBootstrapRespon
 	return &res, nil
 }
 
-func (cl Client) GetLightClientUpdates(period uint64, count uint64) (LightClientUpdatesResponse, error) {
+func (cl Client) GetLightClientUpdates(ctx context.Context, period uint64, count uint64) (LightClientUpdatesResponse, error) {
 	var res LightClientUpdatesResponse
-	if err := cl.get(fmt.Sprintf("/eth/v1/beacon/light_client/updates?start_period=%v&count=%v", period, count), &res); err != nil {
+	if err := cl.get(ctx, fmt.Sprintf("/eth/v1/beacon/light_client/updates?start_period=%v&count=%v", period, count), &res); err != nil {
 		return nil, err
 	}
 	if len(res) != int(count) {
@@ -82,17 +84,17 @@ func (cl Client) GetLightClientUpdates(period uint64, count uint64) (LightClient
 	return res, nil
 }
 
-func (cl Client) GetLightClientUpdate(period uint64) (*LightClientUpdateResponse, error) {
-	res, err := cl.GetLightClientUpdates(period, 1)
+func (cl Client) GetLightClientUpdate(ctx context.Context, period uint64) (*LightClientUpdateResponse, error) {
+	res, err := cl.GetLightClientUpdates(ctx, period, 1)
 	if err != nil {
 		return nil, err
 	}
 	return &res[0], nil
 }
 
-func (cl Client) GetLightClientFinalityUpdate() (*LightClientFinalityUpdateResponse, error) {
+func (cl Client) GetLightClientFinalityUpdate(ctx context.Context) (*LightClientFinalityUpdateResponse, error) {
 	var res LightClientFinalityUpdateResponse
-	if err := cl.get("/eth/v1/beacon/light_client/finality_update", &res); err != nil {
+	if err := cl.get(ctx, "/eth/v1/beacon/light_client/finality_update", &res); err != nil {
 		return nil, err
 	}
 	if !IsSupportedVersion(res.Version) {
@@ -101,9 +103,14 @@ func (cl Client) GetLightClientFinalityUpdate() (*LightClientFinalityUpdateRespo
 	return &res, nil
 }
 
-func (cl Client) get(path string, res any) error {
+func (cl Client) get(ctx context.Context, path string, res any) error {
 	log.GetLogger().Debug("Beacon API request", "endpoint", cl.endpoint+path)
-	r, err := http.Get(cl.endpoint + path)
+	req, err := http.NewRequestWithContext(ctx, "GET", cl.endpoint+path, nil)
+	if err != nil {
+		return err
+	}
+
+	r, err := cl.httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/beacon/client.go
+++ b/beacon/client.go
@@ -15,12 +15,11 @@ import (
 var SupportedVersions = []string{"deneb", "electra"}
 
 type Client struct {
-	endpoint   string
-	httpClient *http.Client
+	endpoint string
 }
 
 func NewClient(endpoint string) Client {
-	return Client{endpoint: endpoint, httpClient: &http.Client{}}
+	return Client{endpoint: endpoint}
 }
 
 func IsSupportedVersion(v string) bool {
@@ -110,7 +109,7 @@ func (cl Client) get(ctx context.Context, path string, res any) error {
 		return err
 	}
 
-	r, err := cl.httpClient.Do(req)
+	r, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.5
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/ibc-go/v8 v8.2.1
-	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16
+	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.17
 	github.com/ethereum/go-ethereum v1.14.12
 	github.com/hyperledger-labs/yui-relayer v0.5.11
 	github.com/prysmaticlabs/fastssz v0.0.0-20241008181541-518c4ce73516

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16 h1:C4xwZ1Pq5O+ITjP5UphpwThtTHnWiTe0V4pckEvqfwI=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16/go.mod h1:sf+ti1uM1joxhukxIyj8oDQ5yf7d+e+nl+3vtn9f5CM=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.17 h1:oyDLIbc9hyp31c3OoIB5wHm51tpyDrYAu1KBA1KxfEw=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.17/go.mod h1:sf+ti1uM1joxhukxIyj8oDQ5yf7d+e+nl+3vtn9f5CM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/relay/beacon.go
+++ b/relay/beacon.go
@@ -69,8 +69,8 @@ func (pr *Prover) computeEpoch(slot uint64) uint64 {
 	return slot / pr.slotsPerEpoch()
 }
 
-func (pr *Prover) getSlotAtTimestamp(timestamp uint64) (uint64, error) {
-	genesis, err := pr.beaconClient.GetGenesis(context.TODO())
+func (pr *Prover) getSlotAtTimestamp(ctx context.Context, timestamp uint64) (uint64, error) {
+	genesis, err := pr.beaconClient.GetGenesis(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -84,12 +84,12 @@ func (pr *Prover) getSlotAtTimestamp(timestamp uint64) (uint64, error) {
 }
 
 // returns a period corresponding to a given execution block number
-func (pr *Prover) getPeriodWithBlockNumber(blockNumber uint64) (uint64, error) {
-	timestamp, err := pr.chain.Timestamp(context.TODO(), pr.newHeight(int64(blockNumber)))
+func (pr *Prover) getPeriodWithBlockNumber(ctx context.Context, blockNumber uint64) (uint64, error) {
+	timestamp, err := pr.chain.Timestamp(ctx, pr.newHeight(int64(blockNumber)))
 	if err != nil {
 		return 0, err
 	}
-	slot, err := pr.getSlotAtTimestamp(uint64(timestamp.Unix()))
+	slot, err := pr.getSlotAtTimestamp(ctx, uint64(timestamp.Unix()))
 	if err != nil {
 		return 0, err
 	}

--- a/relay/beacon.go
+++ b/relay/beacon.go
@@ -70,7 +70,7 @@ func (pr *Prover) computeEpoch(slot uint64) uint64 {
 }
 
 func (pr *Prover) getSlotAtTimestamp(timestamp uint64) (uint64, error) {
-	genesis, err := pr.beaconClient.GetGenesis()
+	genesis, err := pr.beaconClient.GetGenesis(context.TODO())
 	if err != nil {
 		return 0, err
 	}

--- a/relay/execution.go
+++ b/relay/execution.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"encoding/hex"
 	"math/big"
 
@@ -10,6 +11,7 @@ import (
 
 func (pr *Prover) buildAccountUpdate(blockNumber uint64) (*lctypes.AccountUpdate, error) {
 	proof, err := pr.executionClient.GetProof(
+		context.TODO(),
 		pr.chain.Config().IBCAddress(),
 		nil,
 		big.NewInt(int64(blockNumber)),
@@ -37,6 +39,7 @@ func (pr *Prover) buildStateProof(path []byte, height int64) ([]byte, error) {
 
 	// call eth_getProof
 	stateProof, err := pr.executionClient.GetProof(
+		context.TODO(),
 		pr.chain.Config().IBCAddress(),
 		[][]byte{storageKeyHex},
 		big.NewInt(height),

--- a/relay/execution.go
+++ b/relay/execution.go
@@ -9,9 +9,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-func (pr *Prover) buildAccountUpdate(blockNumber uint64) (*lctypes.AccountUpdate, error) {
+func (pr *Prover) buildAccountUpdate(ctx context.Context, blockNumber uint64) (*lctypes.AccountUpdate, error) {
 	proof, err := pr.executionClient.GetProof(
-		context.TODO(),
+		ctx,
 		pr.chain.Config().IBCAddress(),
 		nil,
 		big.NewInt(int64(blockNumber)),
@@ -26,7 +26,7 @@ func (pr *Prover) buildAccountUpdate(blockNumber uint64) (*lctypes.AccountUpdate
 	}, nil
 }
 
-func (pr *Prover) buildStateProof(path []byte, height int64) ([]byte, error) {
+func (pr *Prover) buildStateProof(ctx context.Context, path []byte, height int64) ([]byte, error) {
 	// calculate slot for commitment
 	storageKey := crypto.Keccak256Hash(append(
 		crypto.Keccak256Hash(path).Bytes(),
@@ -39,7 +39,7 @@ func (pr *Prover) buildStateProof(path []byte, height int64) ([]byte, error) {
 
 	// call eth_getProof
 	stateProof, err := pr.executionClient.GetProof(
-		context.TODO(),
+		ctx,
 		pr.chain.Config().IBCAddress(),
 		[][]byte{storageKeyHex},
 		big.NewInt(height),

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -153,7 +153,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 
 	if statePeriod == latestPeriod {
 		latestHeight := cs.GetLatestHeight().(clienttypes.Height)
-		res, err := pr.beaconClient.GetLightClientUpdate(statePeriod)
+		res, err := pr.beaconClient.GetLightClientUpdate(context.TODO(), statePeriod)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get LightClientUpdate: state_period=%v %v", statePeriod, err)
 		}
@@ -161,7 +161,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate hash tree root: %v", err)
 		}
-		bootstrapRes, err := pr.beaconClient.GetBootstrap(root[:])
+		bootstrapRes, err := pr.beaconClient.GetBootstrap(context.TODO(), root[:])
 		if err != nil {
 			return nil, fmt.Errorf("failed to get bootstrap: root=%x %v", root, err)
 		}
@@ -184,7 +184,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 		trustedHeight               = cs.GetLatestHeight().(clienttypes.Height)
 	)
 	pr.GetLogger().Debug("setup headers for updating the light-client", "state_period", statePeriod, "latest_period", latestPeriod, "client_state_latest_height", cs.GetLatestHeight().GetRevisionHeight())
-	res, err := pr.beaconClient.GetLightClientUpdate(statePeriod)
+	res, err := pr.beaconClient.GetLightClientUpdate(context.TODO(), statePeriod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get LightClientUpdate: state_period=%v %v", statePeriod, err)
 	}
@@ -220,7 +220,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 
 // if `blockNumber` is 0, the latest block number is used
 func (pr *Prover) buildInitialState(blockNumber uint64) (*InitialState, error) {
-	res, err := pr.beaconClient.GetLightClientFinalityUpdate()
+	res, err := pr.beaconClient.GetLightClientFinalityUpdate(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get light-client finality update: %v", err)
 	}
@@ -256,11 +256,11 @@ func (pr *Prover) buildInitialState(blockNumber uint64) (*InitialState, error) {
 	}
 	var accountStorageRoot [32]byte
 	copy(accountStorageRoot[:], accountUpdate.AccountStorageRoot)
-	genesis, err := pr.beaconClient.GetGenesis()
+	genesis, err := pr.beaconClient.GetGenesis(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get genesis: %v", err)
 	}
-	res2, err := pr.beaconClient.GetLightClientUpdate(period)
+	res2, err := pr.beaconClient.GetLightClientUpdate(context.TODO(), period)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get LightClientUpdate: period=%v %v", period, err)
 	}
@@ -279,7 +279,7 @@ func (pr *Prover) buildInitialState(blockNumber uint64) (*InitialState, error) {
 // buildLatestFinalizedHeader returns the latest finalized header on this chain
 // The returned header is expected to be the latest one of headers that can be verified by the light client
 func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (headers core.Header, err error) {
-	res, err := pr.beaconClient.GetLightClientFinalityUpdate()
+	res, err := pr.beaconClient.GetLightClientFinalityUpdate(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -396,13 +396,13 @@ func (pr *Prover) getBootstrapInPeriod(period uint64) (*lctypes.SyncCommittee, e
 	pr.GetLogger().Debug("get bootstrap in period", "period", period, "start_slot", startSlot, "last_slot_in_period", lastSlotInPeriod, "slots_per_epoch", slotsPerEpoch)
 	var errs []error
 	for i := startSlot + slotsPerEpoch; i <= lastSlotInPeriod; i += slotsPerEpoch {
-		res, err := pr.beaconClient.GetBlockRoot(i, false)
+		res, err := pr.beaconClient.GetBlockRoot(context.TODO(), i, false)
 		if err != nil {
 			pr.GetLogger().Warn("failed to get block root", "slot", i, "err", err)
 			errs = append(errs, err)
 			return nil, fmt.Errorf("there is no available bootstrap in period: period=%v err=%v", period, errors.Join(errs...))
 		}
-		bootstrap, err := pr.beaconClient.GetBootstrap(res.Data.Root[:])
+		bootstrap, err := pr.beaconClient.GetBootstrap(context.TODO(), res.Data.Root[:])
 		if err != nil {
 			pr.GetLogger().Warn("failed to get bootstrap", "root", res.Data.Root[:], "err", err)
 			errs = append(errs, err)
@@ -415,7 +415,7 @@ func (pr *Prover) getBootstrapInPeriod(period uint64) (*lctypes.SyncCommittee, e
 }
 
 func (pr *Prover) buildNextSyncCommitteeUpdate(period uint64, trustedHeight clienttypes.Height, trustedNextSyncCommittee *lctypes.SyncCommittee) (*lctypes.Header, error) {
-	res, err := pr.beaconClient.GetLightClientUpdate(period)
+	res, err := pr.beaconClient.GetLightClientUpdate(context.TODO(), period)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is the subsequent PR of https://github.com/datachainlab/ethereum-ibc-relay-prover/pull/32 and replaces `context.TODO()` with an appropriate context. 

I have confirmed that the CI of https://github.com/datachainlab/cosmos-ethereum-ibc-lcp passes:

https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/actions/runs/13850650603/job/38757230693