### PR TITLE
Add Pectra HF schedule for Ethereum Mainnet

### DIFF
--- a/relay/config.go
+++ b/relay/config.go
@@ -166,6 +166,11 @@ func (prc *ProverConfig) getForkParameters() *lctypes.ForkParameters {
 					Epoch:   269568,
 					Spec:    &DenebSpec,
 				},
+				{
+					Version: []byte{5, 0, 0, 0},
+					Epoch:   364032,
+					Spec:    &ElectraSpec,
+				},
 			},
 		}
 	case Minimal:


### PR DESCRIPTION
This PR is similar to https://github.com/datachainlab/ethereum-ibc-relay-prover/pull/31 and adds the Pectra HF schedule to the fork parameters for Ethereum Mainnet.

I have confirmed that the CI passes on https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/pull/77.