### PR TITLE
Add the fork parameter for Fulu Mainnet

### DIFF
--- a/relay/config.go
+++ b/relay/config.go
@@ -176,6 +176,12 @@ func (prc *ProverConfig) getForkParameters() *lctypes.ForkParameters {
 					Epoch:   364032,
 					Spec:    &ElectraSpec,
 				},
+				// ref: https://github.com/ethereum/consensus-specs/blob/v1.6.0/configs/mainnet.yaml#L55-L57
+				{
+					Version: []byte{6, 0, 0, 0},
+					Epoch:   411392,
+					Spec:    &FuluSpec,
+				},
 			},
 		}
 	case Minimal:


### PR DESCRIPTION
The fork parameter for Fulu Sepolia has been merged to the prover, but the HF epoch for Mainnet was not finalized at the time.
Now that it is finalized, this PR will add the fork parameter for Mainnet to `getForkParameters`.