### PR TITLE
Return error on non 2xx status from Beacon API

### DIFF
--- a/beacon/client.go
+++ b/beacon/client.go
@@ -123,5 +123,9 @@ func (cl Client) get(ctx context.Context, path string, res any) error {
 	if err != nil {
 		return err
 	}
+	if r.StatusCode < 200 || r.StatusCode >= 300 {
+		log.GetLogger().DebugContext(ctx, "Non 2xx response to Beacon API request", "endpoint", cl.endpoint+path, "status code", r.StatusCode)
+		return fmt.Errorf("request returned status code %d", r.StatusCode)
+	}
 	return json.Unmarshal(bz, &res)
 }

--- a/beacon/client.go
+++ b/beacon/client.go
@@ -124,7 +124,7 @@ func (cl Client) get(ctx context.Context, path string, res any) error {
 		return err
 	}
 	if r.StatusCode < 200 || r.StatusCode >= 300 {
-		log.GetLogger().DebugContext(ctx, "Non 2xx response to Beacon API request", "endpoint", cl.endpoint+path, "status code", r.StatusCode)
+		log.GetLogger().DebugContext(ctx, "Non 2xx response to Beacon API request", "endpoint", cl.endpoint+path, "status code", r.StatusCode, "response body", string(bz))
 		return fmt.Errorf("request returned status code %d", r.StatusCode)
 	}
 	return json.Unmarshal(bz, &res)


### PR DESCRIPTION
If Beacon API returns a non 2xx response such as HTTP 500, the client will still try to unmarshal the response as if it was a successful response. And then:

* If unmarshaling fails (most likely) the error message in the logs can be confusing
* If unmarshaling succeeds, an incorrect value could be returned

This PR makes the client explicitly check for the status code and return an error for non 2xx responses.

Although including the response body in the log would be very helpful for debugging, I left it out due to concerns about the potential for sensitive data in the response. But please let me know if it would be better to include the body. (You may notice that in this PR the error is returned _after_ reading the response body).